### PR TITLE
[Han] 사진 선택 시 저장소 접근 권한 요청 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.codesquad.kotlinphotoframe">
 
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/codesquad/kotlinphotoframe/GalleryActivity.kt
+++ b/app/src/main/java/com/codesquad/kotlinphotoframe/GalleryActivity.kt
@@ -1,5 +1,6 @@
 package com.codesquad.kotlinphotoframe
 
+import android.Manifest
 import android.app.Activity
 import android.content.Intent
 import android.graphics.Bitmap
@@ -37,11 +38,23 @@ class GalleryActivity : AppCompatActivity() {
             }
         }
 
+        val requestPermissionLauncher =
+            registerForActivityResult(ActivityResultContracts.RequestPermission()
+            ) { isGranted: Boolean ->
+                if (isGranted) {
+                    Log.d("AppTest", "권한 승인 ok")
+                    val intent = Intent(Intent.ACTION_PICK) // 갤러리관련 앱
+                    //val intent = Intent(Intent.ACTION_GET_CONTENT)  // 전체 이미지 관련 파일 선택 가능한 화면으로 이동
+                    intent.type = "image/*"
+                    getContent.launch(Intent.createChooser(intent, "Chooser Test"))
+                } else {
+                    Snackbar.make(binding.root, "권한이 승인되지 않았습니다", Snackbar.LENGTH_SHORT ).show()
+                }
+            }
+
         binding.btnOpenGallery.setOnClickListener {
-            val intent = Intent(Intent.ACTION_PICK) // 갤러리로 이동
-            //val intent = Intent(Intent.ACTION_GET_CONTENT)  // 전체 이미지 관련 파일 선택 가능한 화면으로 이동
-            intent.type = "image/*"
-            getContent.launch(intent)
+            requestPermissionLauncher.launch(
+                Manifest.permission.READ_EXTERNAL_STORAGE)
         }
     }
 


### PR DESCRIPTION
사진 선택 시 저장소 접근 권한 요청 다이얼로그가 나타나도록 수정
권한 허용 시 이미지 관련 앱 선택기가 나타남
<img src = "https://user-images.githubusercontent.com/69443895/154851275-c78293b6-1d3b-40b6-b922-698fc4ef4ad9.png" width="200" height="400"/>
